### PR TITLE
Added try/except in Library.read() method

### DIFF
--- a/pubchemtools/datastructures.py
+++ b/pubchemtools/datastructures.py
@@ -817,7 +817,11 @@ class Library:
         compound: Compound
 
         for mol in suppl:
-            self.compounds_list.append(Compound(rdkitmol=mol, autofetch=False))
+            try:
+                self.compounds_list.append(Compound(rdkitmol=mol, autofetch=False))
+            except ValueError:
+                print("ERROR: rdkit could not parse the current molecule. Skipping.")
+                continue
 
         for compound in self.compounds_list:
             compound._linked_libraries.append(self)


### PR DESCRIPTION
Just added a try/except clause in the Library.read() method, if the ValueError exception is raised, ignore the molecule and proceed.

This rdkit error usually happens for "nonsensical" molecules anyway, where the coordination of some atoms is larger than physically possible (5-coordinated N sites)